### PR TITLE
[cherry-pick] gna_plugin: include cmath library to avoid call of overloaded ‘abs(float)’ is ambiguous error

### DIFF
--- a/inference-engine/src/gna_plugin/gna_plugin_config.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin_config.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <cmath>
 #include <gna/gna_config.hpp>
 #include "gna_plugin.hpp"
 #include "gna_plugin_config.hpp"


### PR DESCRIPTION
https://github.com/openvinotoolkit/openvino/pull/3622